### PR TITLE
Change MIPS prefix to /usr/mipsel-linux-gnueabihf

### DIFF
--- a/build_libraries.sh
+++ b/build_libraries.sh
@@ -10,12 +10,12 @@ git clone https://github.com/vdr-projects/libnetceiver/
 # Build libdvbcsa
 ./build_libdvbcsa.sh
 ./build_libdvbcsa.sh --host=arm-linux-gnueabihf --prefix=/usr/arm-linux-gnueabihf/
-./build_libdvbcsa.sh --host=mipsel-linux-gnu --prefix=/usr/mipsel-linux-gnu/
+./build_libdvbcsa.sh --host=mipsel-linux-gnu --prefix=/usr/mipsel-linux-gnueabihf/
 
 # Build openssl
 ./build_openssl.sh linux-generic64
 ./build_openssl.sh --cross-compile-prefix=arm-linux-gnueabihf- --prefix=/usr/arm-linux-gnueabihf/ linux-generic32
-./build_openssl.sh --cross-compile-prefix=mipsel-linux-gnu- --prefix=/usr/mipsel-linux-gnu/ linux-generic32
+./build_openssl.sh --cross-compile-prefix=mipsel-linux-gnu- --prefix=/usr/mipsel-linux-gnueabihf/ linux-generic32
 
 # Build netceiver (x64 only)
 ./build_netceiver.sh


### PR DESCRIPTION
It's apparently important that this is not /usr/mipsel-linux-gnu